### PR TITLE
Get nearest areas and subzones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,6 +2495,11 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "geolib": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.1.tgz",
+      "integrity": "sha512-sfahBXFcgELdpumDZV5b3KWiINkZxC5myAkLk067UUcTmTXaiE9SWmxMEHztn/Eus4JX6kesHxaIuZlniYgUtg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.3.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "geolib": "^3.3.1"
+  }
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { getAreas, getSubzones } from "../";
+import { getAreas, getSubzones, getNearest } from "../";
 import { Region } from "../interfaces";
 
 describe("Getting planning areas", () => {
@@ -47,4 +47,75 @@ describe("Getting subzones", () => {
     const allSubzones = getSubzones();
     expect(Object.keys(allSubzones).length).toBe(318);
   });
+});
+
+describe("Getting nearest locations", () => {
+  const MARINA_BAY_SANDS = { latitude: 1.2836491, longitude: 103.8575854 };
+  const BOTANIC_GARDENS = { latitude: 1.3446015, longitude: 103.8009809 };
+
+  it("should return the closest area and subzone", () => {
+    expect(getNearest(MARINA_BAY_SANDS)).toStrictEqual({
+      areas: {
+        DTC: {
+          name: { en: "Downtown Core", zh: "市中心" },
+          coordinates: { latitude: 1.28506, longitude: 103.8543 },
+          region: "C",
+          distance: 398,
+        },
+      },
+      subzones: {
+        DTC_BAY: {
+          name: { en: "Bayfront" },
+          coordinates: { latitude: 1.28333472525, longitude: 103.858533762 },
+          area: "DTC",
+          distance: 111,
+        },
+      },
+    });
+  });
+
+  it("should return N closest areas and subzones", () => {
+    expect(getNearest(BOTANIC_GARDENS, { closest: 3 })).toStrictEqual({
+      areas: {
+        BKT: {
+          name: { en: "Bukit Timah", zh: "武吉知马" },
+          coordinates: { latitude: 1.32999, longitude: 103.7907 },
+          region: "C",
+          distance: 1989,
+        },
+        CWC: {
+          name: { en: "Central Water Catchment", zh: "中央集水区" },
+          coordinates: { latitude: 1.37666, longitude: 103.80119 },
+          region: "N",
+          distance: 3569,
+        },
+        BKP: {
+          name: { en: "Bukit Panjang", zh: "武吉班让" },
+          coordinates: { latitude: 1.36682, longitude: 103.773 },
+          region: "W",
+          distance: 3977,
+        },
+      },
+      subzones: {
+        BKT_SWC: {
+          name: { en: "Swiss Club" },
+          coordinates: { latitude: 1.34063686622, longitude: 103.79231074 },
+          area: "BKT",
+          distance: 1061,
+        },
+        BKT_HIL: {
+          name: { en: "Hillcrest" },
+          coordinates: { latitude: 1.33315732448, longitude: 103.808229456 },
+          area: "BKT",
+          distance: 1508,
+        },
+        undefined: {
+          name: { en: "Bukit Timah", zh: "武吉知马" },
+          coordinates: { latitude: 1.32999, longitude: 103.7907 },
+          region: "C",
+          distance: 1989,
+        },
+      },
+    });
+  })
 });

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,10 +5,12 @@ interface LocalisedName {
   ta?: string;
 }
 
-interface Coordinates {
+export interface Coordinates {
   latitude: number;
   longitude: number;
 }
+
+type Metres = number;
 
 // Administrative level 1
 export enum Region {
@@ -403,6 +405,7 @@ export enum Subzone {
 interface LocationDetails {
   name: LocalisedName;
   coordinates?: Coordinates;
+  distance?: Metres;
 }
 
 export interface RegionDetails extends LocationDetails {}
@@ -413,4 +416,8 @@ export interface AreaDetails extends LocationDetails {
 
 export interface SubzoneDetails extends LocationDetails {
   area: Area;
+}
+
+export interface ProximityConditions {
+  closest: Metres;
 }


### PR DESCRIPTION
Given a pair of latitude and longitude, return the N nearest areas and subzones. See test file for examples.